### PR TITLE
ci: improve cd pipeline to ensure dist is cleaned up before build done by semantic release

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -67,17 +67,13 @@ jobs:
         run: hatch run examples:check
 
       - name: Check wheels can be built
-        run: hatch build
+        run: hatch build && hatch run cicd:clean_dist
 
       - name: Run tests (codebase)
         run: hatch run tests
 
       - name: Run tests (examples)
         run: hatch run examples:tests
-
-      - uses: actions/upload-artifact@v4 # upload artifacts so they are retained on the job
-        with:
-          path: dist
 
       - name: Python Semantic Release
         id: semantic-release
@@ -93,3 +89,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+
+      - uses: actions/upload-artifact@v4 # upload artifacts so they are retained on the job
+        with:
+          path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ dependencies = [
 localnet_start = [
     "algokit localnet start",
 ]
+clean_dist = "rm -rf dist"
 
 # docs environment
 [tool.hatch.envs.docs]


### PR DESCRIPTION
## Proposed Changes

- Minor patch to ensure dist is cleared up after 'fail-fast' check on whether wheels can be built 