### PR TITLE
refactor: move box storage onto ApplicationContextData

### DIFF
--- a/examples/box/test_contract.py
+++ b/examples/box/test_contract.py
@@ -22,5 +22,5 @@ def test_enums(context: AlgopyTestContext) -> None:
     oca, txn = contract.read_enums()
 
     # Assert
-    assert context.ledger.get_box(b"oca") == op.itob(oca.native)
-    assert context.ledger.get_box(b"txn") == op.itob(txn.native)
+    assert context.ledger.get_box(contract, b"oca") == op.itob(oca.native)
+    assert context.ledger.get_box(contract, b"txn") == op.itob(txn.native)

--- a/examples/marketplace/test_contract.py
+++ b/examples/marketplace/test_contract.py
@@ -63,7 +63,7 @@ def test_first_deposit(
         nonce=test_nonce,
     )
     listing_value = ListingValue.from_bytes(
-        context.ledger.get_box(b"listings" + listing_key.bytes)
+        context.ledger.get_box(contract, b"listings" + listing_key.bytes)
     )
     assert listing_value.deposited == UInt64(10)
 
@@ -100,7 +100,7 @@ def test_deposit(
     )
 
     # Assert
-    assert context.ledger.box_exists(b"listings" + listing_key.bytes)
+    assert context.ledger.box_exists(contract, b"listings" + listing_key.bytes)
 
 
 def test_set_price(
@@ -129,7 +129,7 @@ def test_set_price(
 
     # Assert
     updated_listing = ListingValue.from_bytes(
-        context.ledger.get_box(b"listings" + listing_key.bytes)
+        context.ledger.get_box(contract, b"listings" + listing_key.bytes)
     )
     assert updated_listing.unitary_price == test_unitary_price
 
@@ -173,7 +173,7 @@ def test_buy(
 
     # Assert
     updated_listing = ListingValue.from_bytes(
-        context.ledger.get_box(b"listings" + listing_key.bytes)
+        context.ledger.get_box(contract, b"listings" + listing_key.bytes)
     )
     assert updated_listing.deposited == initial_deposit.native - test_buy_quantity.native
     assert (
@@ -206,7 +206,7 @@ def test_withdraw(
     contract.withdraw(asset=test_asset, nonce=test_nonce)
 
     # Assert
-    assert not context.ledger.box_exists(b"listings" + listing_key.bytes)
+    assert not context.ledger.box_exists(contract, b"listings" + listing_key.bytes)
     assert len(context.txn.last_group.itxn_groups) == 2
 
     payment_txn = context.txn.last_group.get_itxn_group(0).payment(0)

--- a/examples/proof_of_attendance/test_contract.py
+++ b/examples/proof_of_attendance/test_contract.py
@@ -57,9 +57,9 @@ def test_confirm_attendance(
     confirm()
 
     # Assert
-    assert context.ledger.get_box(key_prefix + context.default_sender.bytes) == algopy.op.itob(
-        1001
-    )
+    assert context.ledger.get_box(
+        contract, key_prefix + context.default_sender.bytes
+    ) == algopy.op.itob(1001)
 
 
 @pytest.mark.parametrize(
@@ -88,7 +88,9 @@ def test_claim_poa(
         fee=algopy.UInt64(0),
         asset_amount=algopy.UInt64(0),
     )
-    context.ledger.set_box(key_prefix + context.default_sender.bytes, algopy.op.itob(dummy_poa.id))
+    context.ledger.set_box(
+        contract, key_prefix + context.default_sender.bytes, algopy.op.itob(dummy_poa.id)
+    )
 
     # Act
     claim = getattr(contract, claim_poa)

--- a/src/algopy_testing/__init__.py
+++ b/src/algopy_testing/__init__.py
@@ -1,8 +1,5 @@
 from algopy_testing import arc4, gtxn, itxn
-from algopy_testing._context_helpers.context_storage import (
-    algopy_testing_context,
-    get_test_context,
-)
+from algopy_testing._context_helpers.context_storage import algopy_testing_context
 from algopy_testing._itxn_loader import ITxnGroupLoader, ITxnLoader
 from algopy_testing._value_generators.arc4 import ARC4ValueGenerator
 from algopy_testing.context import AlgopyTestContext

--- a/src/algopy_testing/_context_helpers/__init__.py
+++ b/src/algopy_testing/_context_helpers/__init__.py
@@ -1,6 +1,5 @@
 from algopy_testing._context_helpers.context_storage import (
     algopy_testing_context,
-    get_test_context,
     lazy_context,
 )
 from algopy_testing._context_helpers.ledger_context import LedgerContext
@@ -10,6 +9,5 @@ __all__ = [
     "LedgerContext",
     "TransactionContext",
     "algopy_testing_context",
-    "get_test_context",
     "lazy_context",
 ]

--- a/src/algopy_testing/_context_helpers/context_storage.py
+++ b/src/algopy_testing/_context_helpers/context_storage.py
@@ -20,18 +20,6 @@ if typing.TYPE_CHECKING:
 _var: ContextVar[AlgopyTestContext] = ContextVar("_var")
 
 
-# functions for use by algopy_testing implementations that shouldn't be exposed to the user
-def get_test_context() -> AlgopyTestContext:
-    try:
-        result = _var.get()
-    except LookupError:
-        raise ValueError(
-            "Test context is not initialized! Use `with algopy_testing_context()` to "
-            "access the context manager."
-        ) from None
-    return result
-
-
 class _InternalContext:
     """For accessing implementation specific functions, with a convenient
     single entry point for other modules to import Also allows for a single
@@ -39,7 +27,13 @@ class _InternalContext:
 
     @property
     def value(self) -> AlgopyTestContext:
-        return get_test_context()
+        try:
+            return _var.get()
+        except LookupError:
+            raise ValueError(
+                "Test context is not initialized! Use `with algopy_testing_context()` to "
+                "access the context manager."
+            ) from None
 
     @property
     def ledger(self) -> LedgerContext:
@@ -70,29 +64,17 @@ class _InternalContext:
     def active_application(self) -> algopy.Application:
         return self.ledger.get_application(self.active_group.active_app_id)
 
+    @property
+    def active_app_id(self) -> int:
+        return self.active_group.active_app_id
+
     def get_app_data(
         self,
         app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
     ) -> ApplicationContextData:
-        from algopy_testing.models import Application, Contract
-        from algopy_testing.primitives import UInt64
-
-        if isinstance(app, Contract):
-            app_id = app.__app_id__
-        elif isinstance(app, Application):
-            app_id = app.id.value
-        elif isinstance(app, UInt64):
-            app_id = app.value
-        elif isinstance(app, int):
-            app_id = app
-        else:
-            raise TypeError("invalid type")
-        if app_id == 0:
-            app_id = self.active_group.active_app_id
-        try:
-            return self.ledger.application_data[app_id]
-        except KeyError:
-            raise ValueError("Unknown app id, is there an active transaction?") from None
+        if app == 0:
+            app = self.active_group.active_app_id
+        return self.ledger._get_app_data(app)
 
     def get_asset_data(self, asset_id: int | algopy.UInt64) -> AssetFields:
         try:

--- a/src/algopy_testing/_context_helpers/context_storage.py
+++ b/src/algopy_testing/_context_helpers/context_storage.py
@@ -61,8 +61,8 @@ class _InternalContext:
         return group
 
     @property
-    def active_application(self) -> algopy.Application:
-        return self.ledger.get_application(self.active_group.active_app_id)
+    def active_app(self) -> algopy.Application:
+        return self.ledger.get_app(self.active_group.active_app_id)
 
     @property
     def active_app_id(self) -> int:

--- a/src/algopy_testing/_context_helpers/ledger_context.py
+++ b/src/algopy_testing/_context_helpers/ledger_context.py
@@ -4,6 +4,7 @@ import typing
 from collections import defaultdict
 
 from algopy_testing.constants import MAX_BOX_SIZE
+from algopy_testing.models.account import Account
 from algopy_testing.utils import as_bytes, assert_address_is_valid, get_default_global_fields
 
 if typing.TYPE_CHECKING:
@@ -17,6 +18,7 @@ if typing.TYPE_CHECKING:
 
 class LedgerContext:
     def __init__(self) -> None:
+        """Initialize the LedgerContext with default values."""
         from algopy_testing.models.account import AccountContextData, get_empty_account
 
         self.account_data = defaultdict[str, AccountContextData](get_empty_account)
@@ -29,16 +31,53 @@ class LedgerContext:
         self.app_id = iter(range(1001, 2**64))
 
     def get_account(self, address: str) -> algopy.Account:
+        """Get an account by address.
+
+        Args:
+            address (str): The account address.
+
+        Returns:
+            algopy.Account: The account object.
+        """
         import algopy
 
         assert_address_is_valid(address)
         return algopy.Account(address)
 
     def account_exists(self, address: str) -> bool:
+        """Check if an account exists.
+
+        Args:
+            address (str): The account address.
+
+        Returns:
+            bool: True if the account exists, False otherwise.
+        """
         assert_address_is_valid(address)
         return address in self.account_data
 
+    def update_account(self, address: str, **account_fields: typing.Unpack[AccountFields]) -> None:
+        """Update account fields.
+
+        Args:
+            address (str): The account address.
+            **account_fields: The fields to update.
+        """
+        assert_address_is_valid(address)
+        self.account_data[address].fields.update(account_fields)
+
     def get_asset(self, asset_id: algopy.UInt64 | int) -> algopy.Asset:
+        """Get an asset by ID.
+
+        Args:
+            asset_id (algopy.UInt64 | int): The asset ID.
+
+        Returns:
+            algopy.Asset: The asset object.
+
+        Raises:
+            ValueError: If the asset is not found.
+        """
         import algopy
 
         asset_id = int(asset_id) if isinstance(asset_id, algopy.UInt64) else asset_id
@@ -48,50 +87,169 @@ class LedgerContext:
         return algopy.Asset(asset_id)
 
     def asset_exists(self, asset_id: algopy.UInt64 | int) -> bool:
+        """Check if an asset exists.
+
+        Args:
+            asset_id (algopy.UInt64 | int): The asset ID.
+
+        Returns:
+            bool: True if the asset exists, False otherwise.
+        """
         import algopy
 
         asset_id = int(asset_id) if isinstance(asset_id, algopy.UInt64) else asset_id
         return asset_id in self.asset_data
 
-    def update_account(self, address: str, **account_fields: typing.Unpack[AccountFields]) -> None:
-        assert_address_is_valid(address)
-        self.account_data[address].fields.update(account_fields)
-
     def update_asset(self, asset_id: int, **asset_fields: typing.Unpack[AssetFields]) -> None:
+        """Update asset fields.
+
+        Args:
+            asset_id (int): The asset ID.
+            **asset_fields: The fields to update.
+
+        Raises:
+            ValueError: If the asset is not found.
+        """
         if asset_id not in self.asset_data:
             raise ValueError("Asset not found in testing context!")
         self.asset_data[asset_id].update(asset_fields)
 
     def get_application(self, app: algopy.UInt64 | int) -> algopy.Application:
+        """Get an application by ID.
+
+        Args:
+            app (algopy.UInt64 | int): The application ID.
+
+        Returns:
+            algopy.Application: The application object.
+        """
         import algopy
 
         app_data = self._get_app_data(app)
         return algopy.Application(app_data.app_id)
 
-    def _get_app_data(
-        self, app: algopy.UInt64 | algopy.Application | algopy.Contract | int
-    ) -> ApplicationContextData:
-        app_id = _get_app_id(app)
-        try:
-            return self.application_data[app_id]
-        except KeyError:
-            raise ValueError("Unknown app id, is there an active transaction?") from None
-
     def app_exists(self, app: algopy.UInt64 | int) -> bool:
+        """Check if an application exists.
+
+        Args:
+            app (algopy.UInt64 | int): The application ID.
+
+        Returns:
+            bool: True if the application exists, False otherwise.
+        """
         app_id = _get_app_id(app)
         return app_id in self.application_data
 
     def update_application(
         self, app_id: int, **application_fields: typing.Unpack[ApplicationFields]
     ) -> None:
+        """Update application fields.
+
+        Args:
+            app_id (int): The application ID.
+            **application_fields: The fields to update.
+        """
         app_data = self._get_app_data(app_id)
         app_data.fields.update(application_fields)
+
+    def get_global_state(
+        self,
+        app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
+        key: bytes | algopy.Bytes,
+    ) -> int | bytes:
+        """Get global state for an application.
+
+        Args:
+            app: The application identifier.
+            key: The state key.
+
+        Returns:
+            int | bytes: The state value.
+        """
+        return self._get_app_data(app).global_state[as_bytes(key)]
+
+    def set_global_state(
+        self,
+        app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
+        key: bytes | algopy.Bytes,
+        value: int | bytes | None,
+    ) -> None:
+        """Set global state for an application.
+
+        Args:
+            app: The application identifier.
+            key: The state key.
+            value: The state value.
+        """
+        key_bytes = as_bytes(key)
+        global_state = self._get_app_data(app).global_state
+        if value is None:
+            if key_bytes in global_state:
+                del global_state[key_bytes]
+        else:
+            global_state[key_bytes] = value
+
+    def get_local_state(
+        self,
+        app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
+        account: algopy.Account | str,
+        key: algopy.Bytes | bytes,
+    ) -> int | bytes:
+        """Get local state for an application and account.
+
+        Args:
+            app: The application identifier.
+            account: The account identifier.
+            key: The state key.
+
+        Returns:
+            int | bytes: The state value.
+        """
+        composite_key = (
+            (account.public_key if isinstance(account, Account) else account),
+            as_bytes(key),
+        )
+        return self._get_app_data(app).local_state[composite_key]
+
+    def set_local_state(
+        self,
+        app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
+        account: algopy.Account | str,
+        key: algopy.Bytes | bytes,
+        value: int | bytes | None,
+    ) -> None:
+        """Set local state for an application and account.
+
+        Args:
+            app: The application identifier.
+            account: The account identifier.
+            key: The state key.
+            value: The state value.
+        """
+        account_public_key = account.public_key if isinstance(account, Account) else account
+        key_bytes = as_bytes(key)
+        composite_key = (account_public_key, key_bytes)
+        local_state = self._get_app_data(app).local_state
+        if value is None:
+            if composite_key in local_state:
+                del local_state[composite_key]
+        else:
+            local_state[composite_key] = value
 
     def get_box(
         self,
         app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
         key: algopy.Bytes | bytes,
     ) -> bytes:
+        """Get box content for an application.
+
+        Args:
+            app: The application identifier.
+            key: The box key.
+
+        Returns:
+            bytes: The box content.
+        """
         boxes = self._get_app_data(app).boxes
         return boxes.get(_as_box_key(key), b"")
 
@@ -101,6 +259,13 @@ class LedgerContext:
         key: algopy.Bytes | bytes,
         value: algopy.Bytes | bytes,
     ) -> None:
+        """Set box content for an application.
+
+        Args:
+            app: The application identifier.
+            key: The box key.
+            value: The box content.
+        """
         boxes = self._get_app_data(app).boxes
         boxes[_as_box_key(key)] = as_bytes(value, max_size=MAX_BOX_SIZE)
 
@@ -109,6 +274,15 @@ class LedgerContext:
         app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
         key: algopy.Bytes | bytes,
     ) -> bool:
+        """Delete a box for an application.
+
+        Args:
+            app: The application identifier.
+            key: The box key.
+
+        Returns:
+            bool: True if the box was deleted, False if it didn't exist.
+        """
         boxes = self._get_app_data(app).boxes
         try:
             del boxes[_as_box_key(key)]
@@ -121,15 +295,43 @@ class LedgerContext:
         app: algopy.Contract | algopy.Application | algopy.UInt64 | int,
         key: algopy.Bytes | bytes,
     ) -> bool:
+        """Check if a box exists for an application.
+
+        Args:
+            app: The application identifier.
+            key: The box key.
+
+        Returns:
+            bool: True if the box exists, False otherwise.
+        """
         boxes = self._get_app_data(app).boxes
         return _as_box_key(key) in boxes
 
     def set_block(
         self, index: int, seed: algopy.UInt64 | int, timestamp: algopy.UInt64 | int
     ) -> None:
+        """Set block content.
+
+        Args:
+            index (int): The block index.
+            seed (algopy.UInt64 | int): The block seed.
+            timestamp (algopy.UInt64 | int): The block timestamp.
+        """
         self.blocks[index] = {"seed": int(seed), "timestamp": int(timestamp)}
 
     def get_block_content(self, index: int, key: str) -> int:
+        """Get block content.
+
+        Args:
+            index (int): The block index.
+            key (str): The content key.
+
+        Returns:
+            int: The block content value.
+
+        Raises:
+            ValueError: If the block content is not found.
+        """
         content = self.blocks.get(index, {}).get(key, None)
         if content is None:
             raise ValueError(
@@ -138,6 +340,14 @@ class LedgerContext:
         return content
 
     def patch_global_fields(self, **global_fields: typing.Unpack[GlobalFields]) -> None:
+        """Patch global fields.
+
+        Args:
+            **global_fields: The fields to patch.
+
+        Raises:
+            AttributeError: If invalid fields are provided.
+        """
         from algopy_testing.op.global_values import GlobalFields
 
         invalid_keys = global_fields.keys() - GlobalFields.__annotations__.keys()
@@ -149,8 +359,39 @@ class LedgerContext:
 
         self.global_fields.update(global_fields)
 
+    def _get_app_data(
+        self, app: algopy.UInt64 | algopy.Application | algopy.Contract | int
+    ) -> ApplicationContextData:
+        """Get application data.
+
+        Args:
+            app: The application identifier.
+
+        Returns:
+            ApplicationContextData: The application context data.
+
+        Raises:
+            ValueError: If the application is not found.
+        """
+        app_id = _get_app_id(app)
+        try:
+            return self.application_data[app_id]
+        except KeyError:
+            raise ValueError("Unknown app id, is there an active transaction?") from None
+
 
 def _as_box_key(key_: algopy.Bytes | bytes) -> bytes:
+    """Convert a box key to bytes.
+
+    Args:
+        key_: The box key.
+
+    Returns:
+        bytes: The box key as bytes.
+
+    Raises:
+        ValueError: If the key is invalid.
+    """
     key = as_bytes(key_)
     if not key:
         raise ValueError("invalid box key")
@@ -158,6 +399,17 @@ def _as_box_key(key_: algopy.Bytes | bytes) -> bytes:
 
 
 def _get_app_id(app: algopy.UInt64 | algopy.Application | algopy.Contract | int) -> int:
+    """Get the application ID from various input types.
+
+    Args:
+        app: The application identifier.
+
+    Returns:
+        int: The application ID.
+
+    Raises:
+        TypeError: If an invalid type is provided.
+    """
     from algopy_testing.models import Application, Contract
     from algopy_testing.primitives import UInt64
 

--- a/src/algopy_testing/_context_helpers/ledger_context.py
+++ b/src/algopy_testing/_context_helpers/ledger_context.py
@@ -22,7 +22,7 @@ class LedgerContext:
         from algopy_testing.models.account import AccountContextData, get_empty_account
 
         self.account_data = defaultdict[str, AccountContextData](get_empty_account)
-        self.application_data: dict[int, ApplicationContextData] = {}
+        self.app_data: dict[int, ApplicationContextData] = {}
         self.asset_data: dict[int, AssetFields] = {}
         self.blocks: dict[int, dict[str, int]] = {}
         self.global_fields: GlobalFields = get_default_global_fields()
@@ -114,7 +114,7 @@ class LedgerContext:
             raise ValueError("Asset not found in testing context!")
         self.asset_data[asset_id].update(asset_fields)
 
-    def get_application(self, app: algopy.UInt64 | int) -> algopy.Application:
+    def get_app(self, app: algopy.UInt64 | int) -> algopy.Application:
         """Get an application by ID.
 
         Args:
@@ -138,9 +138,9 @@ class LedgerContext:
             bool: True if the application exists, False otherwise.
         """
         app_id = _get_app_id(app)
-        return app_id in self.application_data
+        return app_id in self.app_data
 
-    def update_application(
+    def update_app(
         self, app_id: int, **application_fields: typing.Unpack[ApplicationFields]
     ) -> None:
         """Update application fields.
@@ -375,7 +375,7 @@ class LedgerContext:
         """
         app_id = _get_app_id(app)
         try:
-            return self.application_data[app_id]
+            return self.app_data[app_id]
         except KeyError:
             raise ValueError("Unknown app id, is there an active transaction?") from None
 

--- a/src/algopy_testing/_value_generators/avm.py
+++ b/src/algopy_testing/_value_generators/avm.py
@@ -164,7 +164,7 @@ class AVMValueGenerator:
 
         new_app_id = id if id is not None else next(lazy_context.ledger.app_id)
 
-        if new_app_id in lazy_context.ledger.application_data:
+        if new_app_id in lazy_context.ledger.app_data:
             raise ValueError(
                 f"Application id {new_app_id} has already been configured in test context!"
             )
@@ -195,7 +195,7 @@ class AVMValueGenerator:
                 raise TypeError(f"incorrect type for {field!r}")
             app_fields[field] = value  # type: ignore[literal-required]
 
-        lazy_context.ledger.application_data[new_app_id] = ApplicationContextData(
+        lazy_context.ledger.app_data[new_app_id] = ApplicationContextData(
             fields=app_fields,
             app_id=new_app_id,
             logs=logs or [],

--- a/src/algopy_testing/context.py
+++ b/src/algopy_testing/context.py
@@ -30,6 +30,15 @@ class AlgopyTestContext:
         default_sender: str | None = None,
         template_vars: dict[str, typing.Any] | None = None,
     ) -> None:
+        """Initialize the AlgopyTestContext.
+
+        :param default_sender: The default sender account address,
+            defaults to None
+        :type default_sender: str | None, optional
+        :param template_vars: Dictionary of template variables, defaults
+            to None
+        :type template_vars: dict[str, typing.Any] | None, optional
+        """
         import algopy
 
         self._default_sender = algopy.Account(
@@ -44,46 +53,70 @@ class AlgopyTestContext:
 
     @property
     def default_sender(self) -> algopy.Account:
+        """Get the default sender account.
+
+        :return: The default sender account
+        :rtype: algopy.Account
+        """
         return self._default_sender
 
     @property
     def any(self) -> AlgopyValueGenerator:
+        """Access the value generators.
+
+        :return: The value generator
+        :rtype: AlgopyValueGenerator
+        """
         return self._value_generator
 
     @property
     def ledger(self) -> LedgerContext:
+        """Access the ledger context.
+
+        :return: The ledger context
+        :rtype: LedgerContext
+        """
         return self._ledger_context
 
     @property
     def txn(self) -> TransactionContext:
+        """Access the transaction context.
+
+        :return: The transaction context
+        :rtype: TransactionContext
+        """
         return self._txn_context
 
     def get_app_for_contract(
         self, contract: algopy.Contract | algopy.ARC4Contract
     ) -> algopy.Application:
-        return self.ledger.get_application(contract.__app_id__)
+        """Get the application for a given contract.
+
+        :param contract: The contract to get the application for
+        :type contract: algopy.Contract | algopy.ARC4Contract
+        :return: The application associated with the contract
+        :rtype: algopy.Application
+        """
+        return self.ledger.get_app(contract.__app_id__)
 
     def set_template_var(self, name: str, value: typing.Any) -> None:
         """Set a template variable for the current context.
 
-        :param name: The name of the template variable.
+        :param name: The name of the template variable
         :type name: str
-        :param value: The value to assign to the template variable.
+        :param value: The value to assign to the template variable
         :type value: Any
-        :param name: str:
-        :param value: Any:
-        :returns: None
         """
         self._template_vars[name] = value
 
     def execute_logicsig(self, lsig: algopy.LogicSig, *args: algopy.Bytes) -> bool | algopy.UInt64:
         """Execute a logic signature using provided args.
 
-        :param lsig: The logic signature to execute.
+        :param lsig: The logic signature to execute
         :type lsig: algopy.LogicSig
         :param args: The logic signature arguments to use
         :type args: algopy.Bytes
-        :return: The result of executing the logic signature function.
+        :return: The result of executing the logic signature function
         :rtype: bool | algopy.UInt64
         """
         self._active_lsig_args = args
@@ -99,7 +132,6 @@ class AlgopyTestContext:
     def reset(self) -> None:
         """Reset the test context to its initial state, clearing all data and
         resetting ID counters."""
-
         self._template_vars.clear()
         self._txn_context = TransactionContext()
         self._ledger_context = LedgerContext()

--- a/src/algopy_testing/decorators/arc4.py
+++ b/src/algopy_testing/decorators/arc4.py
@@ -165,7 +165,7 @@ def create_abimethod_txns(
     method_selector = Bytes(method.get_selector())
     txn_fields = lazy_context.get_txn_op_fields()
 
-    contract_app = lazy_context.ledger.get_application(app_id)
+    contract_app = lazy_context.ledger.get_app(app_id)
     txn_app = txn_fields.setdefault("app_id", contract_app)
     txn_fields.setdefault("sender", lazy_context.value.default_sender)
     if contract_app != txn_app:
@@ -197,7 +197,7 @@ def create_abimethod_txns(
 def create_baremethod_txns(app_id: int) -> list[algopy.gtxn.TransactionBase]:
     txn_fields = lazy_context.get_txn_op_fields()
 
-    contract_app = lazy_context.ledger.get_application(app_id)
+    contract_app = lazy_context.ledger.get_app(app_id)
     txn_fields.setdefault("app_id", contract_app)
 
     txn_fields.setdefault(

--- a/src/algopy_testing/itxn.py
+++ b/src/algopy_testing/itxn.py
@@ -96,7 +96,7 @@ class _BaseInnerTransactionFields:
         fields = {
             **get_txn_defaults(),
             "type": txn_type,
-            "sender": lazy_context.active_application.address,
+            "sender": lazy_context.active_app.address,
             **fields,
         }
         _narrow_covariant_types(fields)

--- a/src/algopy_testing/models/application.py
+++ b/src/algopy_testing/models/application.py
@@ -5,7 +5,7 @@ import typing
 
 from algopy_testing.primitives import UInt64
 from algopy_testing.protocols import UInt64Backed
-from algopy_testing.utils import as_bytes, as_int64
+from algopy_testing.utils import as_int64
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -47,38 +47,7 @@ class ApplicationContextData:
         self.is_creating = False
         self.contract: Contract | None = None
         # TODO: add callables support (similar to side effects in pytest)
-        # TODO: 1.0 add getter to ledger context, get_global_state, get_local_state, get_box
         self.app_logs: Sequence[bytes] = (logs,) if isinstance(logs, bytes) else logs
-
-    def get_global_state(self, key: algopy.Bytes | bytes) -> StateValueType:
-        return self.global_state[as_bytes(key)]
-
-    def set_global_state(self, key: algopy.Bytes | bytes, value: StateValueType | None) -> None:
-        key_bytes = as_bytes(key)
-        if value is None:
-            if key_bytes in self.global_state:
-                del self.global_state[key_bytes]
-        else:
-            self.global_state[key_bytes] = value
-
-    def get_local_state(
-        self, account: algopy.Account | str, key: algopy.Bytes | bytes
-    ) -> StateValueType:
-        account_public_key = account if isinstance(account, str) else account.public_key
-        return self.local_state[(account_public_key, as_bytes(key))]
-
-    def set_local_state(
-        self,
-        account: algopy.Account | str,
-        key: algopy.Bytes | bytes,
-        value: StateValueType | None,
-    ) -> None:
-        account_public_key = account if isinstance(account, str) else account.public_key
-        key_bytes = as_bytes(key)
-        if value is None:
-            del self.local_state[(account_public_key, key_bytes)]
-        else:
-            self.local_state[(account_public_key, key_bytes)] = value
 
 
 class Application(UInt64Backed):

--- a/src/algopy_testing/models/contract.py
+++ b/src/algopy_testing/models/contract.py
@@ -57,7 +57,7 @@ class _ContractMeta(type):
         assert isinstance(instance, Contract)
         cls_state_totals = cls._state_totals or StateTotals()  # type: ignore[attr-defined]
         state_totals = _get_state_totals(instance, cls_state_totals)
-        context.ledger.update_application(
+        context.ledger.update_app(
             app_id,
             global_num_bytes=algopy_testing.UInt64(state_totals.global_bytes),
             global_num_uint=algopy_testing.UInt64(state_totals.global_uints),
@@ -114,7 +114,7 @@ class Contract(metaclass=_ContractMeta):
             ) -> typing.Any:
                 context = lazy_context.value
                 # TODO: 1.0 should populate the app txn as much as possible like abimethod does
-                app = context.ledger.get_application(_get_self_or_active_app_id(self))
+                app = context.ledger.get_app(_get_self_or_active_app_id(self))
                 txns = [context.any.txn.application_call(app_id=app)]
                 with context.txn._maybe_implicit_txn_group(txns):
                     try:

--- a/src/algopy_testing/models/contract.py
+++ b/src/algopy_testing/models/contract.py
@@ -141,8 +141,9 @@ class Contract(metaclass=_ContractMeta):
             unproxied_global_state_type = cls.global_state_types[name]
         except KeyError:
             return attr
-        app_data = lazy_context.get_app_data(_get_self_or_active_app_id(self))
-        value = app_data.get_global_state(name.encode("utf8"))
+        value = lazy_context.ledger.get_global_state(
+            _get_self_or_active_app_id(self), name.encode("utf8")
+        )
         return deserialize(unproxied_global_state_type, value)
 
     def __setattr__(self, name: str, value: typing.Any) -> None:
@@ -162,8 +163,7 @@ class Contract(metaclass=_ContractMeta):
                 box_map._key_prefix = name_bytes
             case Bytes() | UInt64() | BytesBacked() | UInt64Backed() | bool():
                 app_id = _get_self_or_active_app_id(self)
-                app = lazy_context.get_app_data(app_id)
-                app.set_global_state(name_bytes.value, serialize(value))
+                lazy_context.ledger.set_global_state(app_id, name_bytes, serialize(value))
                 cls = type(self)
                 assert isinstance(cls, _ContractMeta)
                 cls.global_state_types[name] = type(value)

--- a/src/algopy_testing/op/global_values.py
+++ b/src/algopy_testing/op/global_values.py
@@ -47,7 +47,7 @@ class _Global:
 
     @property
     def current_application_id(self) -> algopy.Application:
-        app = lazy_context.active_application
+        app = lazy_context.active_app
         app_data = lazy_context.get_app_data(app)
         if app_data.is_creating:
             return Application(0)
@@ -55,7 +55,7 @@ class _Global:
 
     @property
     def creator_address(self) -> algopy.Account:
-        app = lazy_context.active_application
+        app = lazy_context.active_app
         app_data = lazy_context.get_app_data(app)
         return app_data.fields["creator"]
 

--- a/src/algopy_testing/op/misc.py
+++ b/src/algopy_testing/op/misc.py
@@ -293,10 +293,9 @@ class _AppLocal:
     ) -> tuple[algopy.Bytes | algopy.UInt64, bool]:
         account = _get_account(a)
         app = _get_app(b)
-        app_data = lazy_context.get_app_data(app)
         key = _get_bytes(c)
         try:
-            native = app_data.get_local_state(account, key)
+            native = lazy_context.ledger.get_local_state(app, account, key)
         except KeyError:
             # note: returns uint64 when not found, to match AVM
             value: Bytes | UInt64 = UInt64()
@@ -309,10 +308,9 @@ class _AppLocal:
     get_ex_uint64 = get_ex_bytes
 
     def delete(self, a: algopy.Account | algopy.UInt64 | int, b: algopy.Bytes | bytes, /) -> None:
-        app_data = lazy_context.get_app_data(0)
         account = _get_account(a)
         key = _get_bytes(b)
-        app_data.set_local_state(account, key, None)
+        lazy_context.ledger.set_local_state(lazy_context.active_app_id, account, key, None)
 
     def put(
         self,
@@ -321,11 +319,10 @@ class _AppLocal:
         c: algopy.Bytes | algopy.UInt64 | bytes | int,
         /,
     ) -> None:
-        app_data = lazy_context.get_app_data(0)
         account = _get_account(a)
         key = _get_bytes(b)
         value = c.value if isinstance(c, Bytes | UInt64) else c
-        app_data.set_local_state(account, key, value)
+        lazy_context.ledger.set_local_state(lazy_context.active_app_id, account, key, value)
 
 
 AppLocal = _AppLocal()
@@ -344,10 +341,9 @@ class _AppGlobal:
         /,
     ) -> tuple[algopy.Bytes | algopy.UInt64, bool]:
         app = _get_app(a)
-        app_data = lazy_context.get_app_data(app)
         key = _get_bytes(b)
         try:
-            native = app_data.get_global_state(key)
+            native = lazy_context.ledger.get_global_state(app, key)
         except KeyError:
             # note: returns uint64 when not found, to match AVM
             value: Bytes | UInt64 = UInt64()
@@ -360,9 +356,8 @@ class _AppGlobal:
     get_ex_uint64 = get_ex_bytes
 
     def delete(self, a: algopy.Bytes | bytes, /) -> None:
-        app_data = lazy_context.get_app_data(0)
         key = _get_bytes(a)
-        app_data.set_global_state(key, None)
+        lazy_context.ledger.set_global_state(lazy_context.active_app_id, key, None)
 
     def put(
         self,
@@ -370,10 +365,9 @@ class _AppGlobal:
         b: algopy.Bytes | algopy.UInt64 | bytes | int,
         /,
     ) -> None:
-        app_data = lazy_context.get_app_data(0)
         key = _get_bytes(a)
         value = b.value if isinstance(b, Bytes | UInt64) else b
-        app_data.set_global_state(key, value)
+        lazy_context.ledger.set_global_state(lazy_context.active_app_id, key, value)
 
 
 AppGlobal = _AppGlobal()

--- a/src/algopy_testing/op/misc.py
+++ b/src/algopy_testing/op/misc.py
@@ -24,7 +24,7 @@ def _get_app(app: algopy.Application | algopy.UInt64 | int) -> Application:
     if isinstance(app, Application):
         return app
     if app >= 1001:
-        return lazy_context.ledger.get_application(app)
+        return lazy_context.ledger.get_app(app)
     txn = lazy_context.active_group.active_txn
     return txn.apps(app)
 

--- a/src/algopy_testing/state/global_state.py
+++ b/src/algopy_testing/state/global_state.py
@@ -92,9 +92,8 @@ class GlobalState(typing.Generic[_T]):
             if self._pending_value is not None:
                 return self._pending_value
             raise ValueError("Key is not set")
-        app_data = lazy_context.get_app_data(self.app_id)
         try:
-            native = app_data.get_global_state(self._key.value)
+            native = lazy_context.ledger.get_global_state(self.app_id, self._key)
         except KeyError as e:
             raise ValueError("Value is not set") from e
         return deserialize(self.type_, native)
@@ -104,16 +103,14 @@ class GlobalState(typing.Generic[_T]):
         if self._key is None:
             self._pending_value = value
         else:
-            app_data = lazy_context.get_app_data(self.app_id)
-            app_data.set_global_state(self._key.value, serialize(value))
+            lazy_context.ledger.set_global_state(self.app_id, self._key, serialize(value))
 
     @value.deleter
     def value(self) -> None:
         if self._key is None:
             self._pending_value = None
         else:
-            app_data = lazy_context.get_app_data(self.app_id)
-            app_data.set_global_state(self._key.value, None)
+            lazy_context.ledger.set_global_state(self.app_id, self._key, None)
 
     def __bool__(self) -> bool:
         return self._key is not None or self._pending_value is not None

--- a/src/algopy_testing/state/local_state.py
+++ b/src/algopy_testing/state/local_state.py
@@ -48,25 +48,21 @@ class LocalState(typing.Generic[_T]):
 
     def __setitem__(self, key: algopy.Account | algopy.UInt64 | int, value: _T) -> None:
         account = _get_account(key)
-        app_data = lazy_context.get_app_data(self.app_id)
-        app_data.set_local_state(account, self._key.value, serialize(value))
+        lazy_context.ledger.set_local_state(self.app_id, account, self._key, serialize(value))
 
     def __getitem__(self, key: algopy.Account | algopy.UInt64 | int) -> _T:
         account = _get_account(key)
-        app_data = lazy_context.get_app_data(self.app_id)
-        native = app_data.get_local_state(account, self._key.value)
+        native = lazy_context.ledger.get_local_state(self.app_id, account, self._key)
         return deserialize(self.type_, native)
 
     def __delitem__(self, key: algopy.Account | algopy.UInt64 | int) -> None:
         account = _get_account(key)
-        app_data = lazy_context.get_app_data(self.app_id)
-        app_data.set_local_state(account, self._key.value, None)
+        lazy_context.ledger.set_local_state(self.app_id, account, self._key, None)
 
     def __contains__(self, key: algopy.Account | algopy.UInt64 | int) -> bool:
         account = _get_account(key)
-        app_data = lazy_context.get_app_data(self.app_id)
         try:
-            app_data.get_local_state(account, self._key.value)
+            lazy_context.ledger.get_local_state(self.app_id, account, self._key)
         except KeyError:
             return False
         return True

--- a/tests/models/test_box.py
+++ b/tests/models/test_box.py
@@ -23,7 +23,8 @@ class ATestContract(algopy.Contract):
 @pytest.fixture()
 def context() -> Generator[AlgopyTestContext, None, None]:
     with algopy_testing_context() as ctx:
-        yield ctx
+        with ctx.txn.create_group([ctx.any.txn.application_call()]):
+            yield ctx
         ctx.reset()
 
 

--- a/tests/models/test_box_map.py
+++ b/tests/models/test_box_map.py
@@ -23,7 +23,8 @@ class ATestContract(algopy.Contract):
 @pytest.fixture()
 def context() -> Generator[AlgopyTestContext, None, None]:
     with algopy_testing_context() as ctx:
-        yield ctx
+        with ctx.txn.create_group([ctx.any.txn.application_call()]):
+            yield ctx
         ctx.reset()
 
 

--- a/tests/models/test_box_ref.py
+++ b/tests/models/test_box_ref.py
@@ -22,7 +22,8 @@ class ATestContract(algopy.ARC4Contract):
 @pytest.fixture()
 def context() -> Generator[AlgopyTestContext, None, None]:
     with algopy_testing_context() as ctx:
-        yield ctx
+        with ctx.txn.create_group([ctx.any.txn.application_call()]):
+            yield ctx
         ctx.reset()
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -57,7 +57,7 @@ def test_application_management() -> None:
             clear_state_program=Bytes(b"TestClear"),
         )
 
-        application = context.ledger.get_application(app.id)
+        application = context.ledger.get_app(app.id)
 
         assert application.approval_program == b"TestApp"
         assert application.clear_state_program == b"TestClear"
@@ -114,7 +114,7 @@ def test_context_reset() -> None:
         context.reset()
         assert len(context.ledger.account_data) == 0
         assert len(context.ledger.asset_data) == 0
-        assert len(context.ledger.application_data) == 0
+        assert len(context.ledger.app_data) == 0
         with pytest.raises(ValueError, match="No group transactions found"):
             assert context.txn.last_group
         assert len(context.txn._groups) == 0


### PR DESCRIPTION
* Moves boxes onto ApplicationContextData, this ensures box data is explicit about which app it belongs to
* Ledger methods for interacting with boxes now require an app reference
* Replaced last usage of get_test_context() with lazy_context