### PR TITLE
fix: ability to pass kw_only flag to dataclass when defining struct subclass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+    - package-ecosystem: "pip"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      commit-message:
+          prefix: "chore(deps)"
+      groups:
+          all:
+              patterns:
+                  - "*"
+              update-types:
+                  - "minor"
+                  - "patch"

--- a/src/_algopy_testing/arc4.py
+++ b/src/_algopy_testing/arc4.py
@@ -1053,8 +1053,8 @@ class Struct(MutableBytes, _ABIEncoded, metaclass=_StructMeta):  # type: ignore[
 
     _type_info: typing.ClassVar[_StructTypeInfo]  # type: ignore[misc]
 
-    def __init_subclass__(cls, **kwargs: dict[str, typing.Any]) -> None:
-        dataclasses.dataclass(cls, **kwargs)
+    def __init_subclass__(cls, *args: typing.Any, **kwargs: dict[str, typing.Any]) -> None:
+        dataclasses.dataclass(cls, *args, **kwargs)
         cls._type_info = _StructTypeInfo(cls)
 
     def __post_init__(self) -> None:

--- a/src/_algopy_testing/arc4.py
+++ b/src/_algopy_testing/arc4.py
@@ -1053,8 +1053,8 @@ class Struct(MutableBytes, _ABIEncoded, metaclass=_StructMeta):  # type: ignore[
 
     _type_info: typing.ClassVar[_StructTypeInfo]  # type: ignore[misc]
 
-    def __init_subclass__(cls) -> None:
-        dataclasses.dataclass(cls)
+    def __init_subclass__(cls, **kwargs: dict[str, typing.Any]) -> None:
+        dataclasses.dataclass(cls, **kwargs)
         cls._type_info = _StructTypeInfo(cls)
 
     def __post_init__(self) -> None:

--- a/tests/arc4/test_struct.py
+++ b/tests/arc4/test_struct.py
@@ -16,6 +16,13 @@ _arc4_uint64 = arc4.UInt64(42)
 _arc4_bool = arc4.Bool(True)
 
 
+class StructWithKwOnly(arc4.Struct, kw_only=True):
+    a: arc4.UInt64
+    b: arc4.UInt64
+    c: arc4.Bool
+    d: arc4.String
+
+
 class Swapped(arc4.Struct):
     b: arc4.UInt64
     c: arc4.Bool
@@ -327,6 +334,19 @@ def test_from_bytes(abi_type: abi.ABIType, abi_value: tuple, arc4_type: type[Swa
         i += 1
 
     assert len(abi_value) == len(arc4_result)
+
+
+def test_struct_kw_only() -> None:
+    struct = StructWithKwOnly(
+        a=arc4.UInt64(1), b=arc4.UInt64(2), c=arc4.Bool(True), d=arc4.String("hello")
+    )
+    assert struct.a == 1
+    assert struct.b == 2
+    assert struct.c.native
+    assert struct.d == "hello"
+
+    with pytest.raises(TypeError, match="takes 1 positional argument but 5 were given"):
+        StructWithKwOnly(arc4.UInt64(1), arc4.UInt64(2), arc4.Bool(True), arc4.String("hello"))  # type: ignore[misc]
 
 
 def _compare_abi_and_arc4_values(


### PR DESCRIPTION
## Proposed Changes

- Reported by Giorgio, passing kw_only flag to definition of Struct subclass was not recognized by the testing implementation
- Minor addition of dependabot.yaml used across other algokit python projects