### PR TITLE
fix: fixes type checking of tuples with primitive types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,16 @@ jobs:
         run: pipx install algokit && algokit localnet start
 
       - name: Run tests with Python ${{ matrix.python-version }}
-        run: hatch run test:ci
+        run: hatch run test.py${{ matrix.python-version }}:ci
 
       - name: Run examples tests with Python ${{ matrix.python-version }}
-        run: hatch run examples:tests
+        run: hatch run examples.py${{ matrix.python-version }}:tests
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ matrix.python-version == '3.13' }}
+        with:
+          name: coverage-reports
+          path: |
+            ./coverage.xml
+          retention-days: 14

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,11 +37,32 @@ jobs:
       - name: Check wheels can be built
         run: hatch build
 
-      - name: Run tests (codebase)
-        run: hatch run tests
-
-      - name: Run tests (examples)
-        run: hatch run examples:tests
-
       - name: Check doctests
         run: hatch run docs:test
+
+  test-python-matrix:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install hatch
+        run: pip install hatch
+
+      - name: Start LocalNet
+        run: pipx install algokit && algokit localnet start
+
+      - name: Run tests with Python ${{ matrix.python-version }}
+        run: hatch run test:ci
+
+      - name: Run examples tests with Python ${{ matrix.python-version }}
+        run: hatch run examples:tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/algopy", 'src/algopy_testing', 'src/_algopy_testing']
 
-[[tool.hatch.envs.all.matrix]]
-python = ["3.12", "3.13"]
-
 # default dev environment
 [tool.hatch.envs.default]
 type = "virtual"
@@ -122,6 +119,7 @@ path = ".venv.cicd"
 dependencies = [
     "python-semantic-release>=9.8.5",
 ]
+
 [tool.hatch.envs.cicd.scripts]
 clean_dist = "rm -rf dist"
 
@@ -179,7 +177,6 @@ dev = "hatch run docs:test  && sphinx-autobuild docs docs/_build"
 [tool.hatch.envs.examples]
 type = "virtual"
 path = ".venv.examples"
-python = "3.12"
 dev-mode = true
 skip-install = false
 post-install-commands = [
@@ -207,6 +204,9 @@ check = [
     "hatch run lint:check_examples",
     "hatch run mypy examples",
 ]
+
+[[tool.hatch.envs.examples.matrix]]
+python = ["3.12", "3.13"]
 
 # tool configurations
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     # ==========================================================================
@@ -44,7 +45,7 @@ allow-direct-references = true
 packages = ["src/algopy", 'src/algopy_testing', 'src/_algopy_testing']
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.12"]
+python = ["3.12", "3.13"]
 
 # default dev environment
 [tool.hatch.envs.default]
@@ -123,6 +124,25 @@ dependencies = [
 ]
 [tool.hatch.envs.cicd.scripts]
 clean_dist = "rm -rf dist"
+
+# Testing environment with matrix
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.4",
+    "pytest-mock>=3.10.0",
+    "pytest-xdist[psutil]>=3.3",
+    "pytest-cov>=4.1.0",
+    "py-algorand-sdk>=2.4.0",
+    "algokit-utils>=3.0.0",
+    "puyapy>=3.0",
+]
+
+[tool.hatch.envs.test.scripts]
+run = "pytest --cov=src --cov-report=xml {args}"
+ci = "pytest --cov=src --cov-report=xml --cov-report=term"
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.12", "3.13"]
 
 # docs environment
 [tool.hatch.envs.docs]

--- a/src/_algopy_testing/serialize.py
+++ b/src/_algopy_testing/serialize.py
@@ -25,66 +25,71 @@ def identity(i: _T) -> _T:
     return i
 
 
-def get_native_to_arc4_serializer(typ: type[_T]) -> _Serializer:  # type: ignore[type-arg] # noqa: PLR0911
+def get_native_to_arc4_serializer(typ: type[_T]) -> _Serializer:  # type: ignore[type-arg]  # noqa: PLR0911, PLR0912
     from _algopy_testing import arc4
     from _algopy_testing.models import Account
     from _algopy_testing.primitives import BigUInt, Bytes, ImmutableArray, String
     from _algopy_testing.protocols import UInt64Backed
 
-    if issubclass(typ, arc4._ABIEncoded):
+    origin_typ = typing.get_origin(typ)
+
+    if inspect.isclass(typ) and issubclass(typ, arc4._ABIEncoded):
         return _Serializer(
             native_type=typ, arc4_type=typ, native_to_arc4=identity, arc4_to_native=identity
         )
-    if issubclass(typ, bool):
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.Bool,
-            native_to_arc4=arc4.Bool,
-            arc4_to_native=lambda n: n.native,
-        )
-    if issubclass(typ, UInt64Backed):
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.UInt64,
-            native_to_arc4=lambda n: arc4.UInt64(n.int_),
-            arc4_to_native=lambda a: typ.from_int(a.native),
-        )
-    if issubclass(typ, BigUInt):
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.UInt512,
-            native_to_arc4=arc4.UInt512,
-            arc4_to_native=lambda a: a.native,
-        )
-    if issubclass(typ, Account):
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.Address,
-            native_to_arc4=arc4.Address,
-            arc4_to_native=lambda a: a.native,
-        )
-    if issubclass(typ, UInt64):
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.UInt64,
-            native_to_arc4=arc4.UInt64,
-            arc4_to_native=lambda a: a.native,
-        )
-    if issubclass(typ, Bytes):
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.DynamicBytes,
-            native_to_arc4=arc4.DynamicBytes,
-            arc4_to_native=lambda a: a.native,
-        )
-    if issubclass(typ, String):
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.String,
-            native_to_arc4=arc4.String,
-            arc4_to_native=lambda a: a.native,
-        )
-    if issubclass(typ, tuple) or typing.get_origin(typ) is tuple:
+    # For types that are expected to be simple classes for these specific checks
+    if inspect.isclass(typ):
+        if issubclass(typ, bool):
+            return _Serializer(
+                native_type=typ,
+                arc4_type=arc4.Bool,
+                native_to_arc4=arc4.Bool,
+                arc4_to_native=lambda n: n.native,
+            )
+        if issubclass(typ, UInt64Backed):
+            return _Serializer(
+                native_type=typ,
+                arc4_type=arc4.UInt64,
+                native_to_arc4=lambda n: arc4.UInt64(n.int_),
+                arc4_to_native=lambda a: typ.from_int(a.native),
+            )
+        if issubclass(typ, BigUInt):
+            return _Serializer(
+                native_type=typ,
+                arc4_type=arc4.UInt512,
+                native_to_arc4=arc4.UInt512,
+                arc4_to_native=lambda a: a.native,
+            )
+        if issubclass(typ, Account):
+            return _Serializer(
+                native_type=typ,
+                arc4_type=arc4.Address,
+                native_to_arc4=arc4.Address,
+                arc4_to_native=lambda a: a.native,
+            )
+        if issubclass(typ, UInt64):
+            return _Serializer(
+                native_type=typ,
+                arc4_type=arc4.UInt64,
+                native_to_arc4=arc4.UInt64,
+                arc4_to_native=lambda a: a.native,
+            )
+        if issubclass(typ, Bytes):
+            return _Serializer(
+                native_type=typ,
+                arc4_type=arc4.DynamicBytes,
+                native_to_arc4=arc4.DynamicBytes,
+                arc4_to_native=lambda a: a.native,
+            )
+        if issubclass(typ, String):
+            return _Serializer(
+                native_type=typ,
+                arc4_type=arc4.String,
+                native_to_arc4=arc4.String,
+                arc4_to_native=lambda a: a.native,
+            )
+
+    if origin_typ is tuple or (inspect.isclass(typ) and issubclass(typ, tuple)):
         if typing.NamedTuple in getattr(typ, "__orig_bases__", []):
             tuple_fields: Sequence[type] = list(inspect.get_annotations(typ).values())
         else:

--- a/src/_algopy_testing/serialize.py
+++ b/src/_algopy_testing/serialize.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import inspect
 import typing
 from collections.abc import Callable, Sequence
@@ -15,7 +16,6 @@ _U = typing.TypeVar("_U")
 
 @dataclasses.dataclass(frozen=True)
 class _Serializer(typing.Generic[_T, _U]):
-    native_type: type[_T]
     arc4_type: type[_U]
     native_to_arc4: Callable[[_T], _U]
     arc4_to_native: Callable[[_U], _T]
@@ -25,109 +25,90 @@ def identity(i: _T) -> _T:
     return i
 
 
-def get_native_to_arc4_serializer(typ: type[_T]) -> _Serializer:  # type: ignore[type-arg]  # noqa: PLR0911, PLR0912
+def get_native_to_arc4_serializer(typ: type) -> _Serializer[typing.Any, typing.Any]:
     from _algopy_testing import arc4
-    from _algopy_testing.models import Account
-    from _algopy_testing.primitives import BigUInt, Bytes, ImmutableArray, String
+    from _algopy_testing.primitives import ImmutableArray
     from _algopy_testing.protocols import UInt64Backed
 
-    origin_typ = typing.get_origin(typ)
-
-    if inspect.isclass(typ) and issubclass(typ, arc4._ABIEncoded):
-        return _Serializer(
-            native_type=typ, arc4_type=typ, native_to_arc4=identity, arc4_to_native=identity
-        )
-    # For types that are expected to be simple classes for these specific checks
-    if inspect.isclass(typ):
-        if issubclass(typ, bool):
-            return _Serializer(
-                native_type=typ,
-                arc4_type=arc4.Bool,
-                native_to_arc4=arc4.Bool,
-                arc4_to_native=lambda n: n.native,
-            )
+    origin_type = typing.get_origin(typ)
+    if origin_type is tuple:
+        return _get_tuple_serializer(typing.get_args(typ))
+    elif isinstance(typ, type):
+        if issubclass(typ, arc4._ABIEncoded):
+            return _Serializer(arc4_type=typ, native_to_arc4=identity, arc4_to_native=identity)
+        for native_type, simple_arc4_type in _simple_native_to_arc4_type_map().items():
+            if issubclass(typ, native_type):
+                return _Serializer(
+                    arc4_type=simple_arc4_type,
+                    native_to_arc4=simple_arc4_type,
+                    arc4_to_native=lambda n: n.native,
+                )
         if issubclass(typ, UInt64Backed):
             return _Serializer(
-                native_type=typ,
                 arc4_type=arc4.UInt64,
                 native_to_arc4=lambda n: arc4.UInt64(n.int_),
                 arc4_to_native=lambda a: typ.from_int(a.native),
             )
-        if issubclass(typ, BigUInt):
-            return _Serializer(
-                native_type=typ,
-                arc4_type=arc4.UInt512,
-                native_to_arc4=arc4.UInt512,
-                arc4_to_native=lambda a: a.native,
-            )
-        if issubclass(typ, Account):
-            return _Serializer(
-                native_type=typ,
-                arc4_type=arc4.Address,
-                native_to_arc4=arc4.Address,
-                arc4_to_native=lambda a: a.native,
-            )
-        if issubclass(typ, UInt64):
-            return _Serializer(
-                native_type=typ,
-                arc4_type=arc4.UInt64,
-                native_to_arc4=arc4.UInt64,
-                arc4_to_native=lambda a: a.native,
-            )
-        if issubclass(typ, Bytes):
-            return _Serializer(
-                native_type=typ,
-                arc4_type=arc4.DynamicBytes,
-                native_to_arc4=arc4.DynamicBytes,
-                arc4_to_native=lambda a: a.native,
-            )
-        if issubclass(typ, String):
-            return _Serializer(
-                native_type=typ,
-                arc4_type=arc4.String,
-                native_to_arc4=arc4.String,
-                arc4_to_native=lambda a: a.native,
-            )
-
-    if origin_typ is tuple or (inspect.isclass(typ) and issubclass(typ, tuple)):
         if typing.NamedTuple in getattr(typ, "__orig_bases__", []):
-            tuple_fields: Sequence[type] = list(inspect.get_annotations(typ).values())
-        else:
-            tuple_fields = typing.get_args(typ)
-        serializers = [get_native_to_arc4_serializer(i) for i in tuple_fields]
-
-        def _items_to_arc4(items: Sequence[object]) -> tuple[object, ...]:
-            result = []
-            for item, serializer in zip(items, serializers, strict=True):
-                result.append(serializer.native_to_arc4(item))
-            return tuple(result)
-
-        def _items_to_native(items: Sequence[object]) -> tuple[object, ...]:
-            result = []
-            for item, serializer in zip(items, serializers, strict=True):
-                result.append(serializer.arc4_to_native(item))
-            return tuple(result)
-
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4.Tuple[*(s.arc4_type for s in serializers)],  # type: ignore[misc]
-            native_to_arc4=lambda t: arc4.Tuple(_items_to_arc4(t)),
-            arc4_to_native=lambda t: _items_to_native(t),
-        )
-    if issubclass(typ, ImmutableArray):
-        native_element_type = typ._element_type
-        element_serializer = get_native_to_arc4_serializer(native_element_type)
-        arc4_element_type = element_serializer.arc4_type
-        arc4_type = arc4.DynamicArray[arc4_element_type]  # type: ignore[valid-type]
-        return _Serializer(
-            native_type=typ,
-            arc4_type=arc4_type,
-            native_to_arc4=lambda arr: arc4_type(
-                *(element_serializer.native_to_arc4(e) for e in arr)
-            ),
-            arc4_to_native=lambda arr: typ(*(element_serializer.arc4_to_native(e) for e in arr)),
-        )
+            tuple_fields = tuple(inspect.get_annotations(typ).values())
+            if any(isinstance(f, str) for f in tuple_fields):
+                raise TypeError("string annotations in typing.NamedTuple fields are not supported")
+            return _get_tuple_serializer(tuple_fields)
+        if issubclass(typ, ImmutableArray):
+            native_element_type = typ._element_type
+            element_serializer = get_native_to_arc4_serializer(native_element_type)
+            arc4_element_type = element_serializer.arc4_type
+            arc4_type = arc4.DynamicArray[arc4_element_type]  # type: ignore[valid-type]
+            return _Serializer(
+                arc4_type=arc4_type,
+                native_to_arc4=lambda arr: arc4_type(
+                    *(element_serializer.native_to_arc4(e) for e in arr)
+                ),
+                arc4_to_native=lambda arr: typ(
+                    *(element_serializer.arc4_to_native(e) for e in arr)
+                ),
+            )
     raise TypeError(f"unserializable type: {typ}")
+
+
+@functools.cache
+def _simple_native_to_arc4_type_map() -> dict[type, type]:
+    from _algopy_testing import arc4
+    from _algopy_testing.models import Account
+    from _algopy_testing.primitives import BigUInt, Bytes, String
+
+    return {
+        bool: arc4.Bool,
+        UInt64: arc4.UInt64,
+        BigUInt: arc4.UInt512,
+        Account: arc4.Address,
+        Bytes: arc4.DynamicBytes,
+        String: arc4.String,
+    }
+
+
+def _get_tuple_serializer(item_types: tuple[type, ...]) -> _Serializer[typing.Any, typing.Any]:
+    from _algopy_testing import arc4
+
+    serializers = [get_native_to_arc4_serializer(i) for i in item_types]
+
+    def _items_to_arc4(items: Sequence[object]) -> tuple[object, ...]:
+        result = []
+        for item, serializer in zip(items, serializers, strict=True):
+            result.append(serializer.native_to_arc4(item))
+        return tuple(result)
+
+    def _items_to_native(items: Sequence[object]) -> tuple[object, ...]:
+        result = []
+        for item, serializer in zip(items, serializers, strict=True):
+            result.append(serializer.arc4_to_native(item))
+        return tuple(result)
+
+    return _Serializer(
+        arc4_type=arc4.Tuple[*(s.arc4_type for s in serializers)],  # type: ignore[misc]
+        native_to_arc4=lambda t: arc4.Tuple(_items_to_arc4(t)),
+        arc4_to_native=lambda t: _items_to_native(t),
+    )
 
 
 def serialize_to_bytes(value: object) -> bytes:

--- a/tests/arc4/test_tuple.py
+++ b/tests/arc4/test_tuple.py
@@ -2,8 +2,10 @@ import typing
 
 import pytest
 from _algopy_testing import arc4
+from algopy_testing import AlgopyTestContext, algopy_testing_context
 from algosdk import abi
 
+from tests.artifacts.Tuples.contract import TuplesContract
 from tests.util import int_to_bytes
 
 _abi_string = "hello"
@@ -14,6 +16,14 @@ _abi_bool = True
 _arc4_string = arc4.String("hello")
 _arc4_uint8 = arc4.UInt8(42)
 _arc4_bool = arc4.Bool(True)
+
+
+# New fixture
+@pytest.fixture()
+def context() -> typing.Generator[AlgopyTestContext, None, None]:
+    with algopy_testing_context() as ctx:
+        yield ctx
+
 
 _test_data = [
     (
@@ -279,3 +289,8 @@ def _compare_abi_and_arc4_values(
         assert arc4_value.native == abi_value
     else:
         assert arc4_value.bytes == int_to_bytes(abi_value, len(arc4_value.bytes))
+
+
+def test_tuple_return_with_primitive_type(context: AlgopyTestContext) -> None:  # noqa: ARG001
+    contract = TuplesContract()
+    contract.test_tuple_with_primitive_type()

--- a/tests/artifacts/Tuples/contract.py
+++ b/tests/artifacts/Tuples/contract.py
@@ -1,0 +1,11 @@
+from algopy import (
+    ARC4Contract,
+    UInt64,
+    arc4,
+)
+
+
+class TuplesContract(ARC4Contract, avm_version=11):
+    @arc4.abimethod()
+    def test_tuple_with_primitive_type(self) -> tuple[UInt64, bool]:
+        return (UInt64(0), True)

--- a/tests/artifacts/Tuples/data/TuplesContract.approval.teal
+++ b/tests/artifacts/Tuples/data/TuplesContract.approval.teal
@@ -1,0 +1,42 @@
+#pragma version 11
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.approval_program() -> uint64:
+main:
+    // tests/artifacts/Tuples/contract.py:8
+    // class TuplesContract(ARC4Contract, avm_version=11):
+    txn NumAppArgs
+    bz main_bare_routing@6
+    pushbytes 0x7229d79a // method "test_tuple_with_primitive_type()(uint64,bool)"
+    txna ApplicationArgs 0
+    match main_test_tuple_with_primitive_type_route@3
+
+main_after_if_else@10:
+    // tests/artifacts/Tuples/contract.py:8
+    // class TuplesContract(ARC4Contract, avm_version=11):
+    pushint 0 // 0
+    return
+
+main_test_tuple_with_primitive_type_route@3:
+    // tests/artifacts/Tuples/contract.py:9
+    // @arc4.abimethod()
+    txn OnCompletion
+    !
+    assert // OnCompletion is not NoOp
+    txn ApplicationID
+    assert // can only call when not creating
+    pushbytes 0x151f7c75000000000000000080
+    log
+    pushint 1 // 1
+    return
+
+main_bare_routing@6:
+    // tests/artifacts/Tuples/contract.py:8
+    // class TuplesContract(ARC4Contract, avm_version=11):
+    txn OnCompletion
+    bnz main_after_if_else@10
+    txn ApplicationID
+    !
+    assert // can only call when creating
+    pushint 1 // 1
+    return

--- a/tests/artifacts/Tuples/data/TuplesContract.arc32.json
+++ b/tests/artifacts/Tuples/data/TuplesContract.arc32.json
@@ -1,0 +1,50 @@
+{
+    "hints": {
+        "test_tuple_with_primitive_type()(uint64,bool)": {
+            "call_config": {
+                "no_op": "CALL"
+            }
+        }
+    },
+    "source": {
+        "approval": "I3ByYWdtYSB2ZXJzaW9uIDExCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuYXBwcm92YWxfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIC8vIHRlc3RzL2FydGlmYWN0cy9UdXBsZXMvY29udHJhY3QucHk6OAogICAgLy8gY2xhc3MgVHVwbGVzQ29udHJhY3QoQVJDNENvbnRyYWN0LCBhdm1fdmVyc2lvbj0xMSk6CiAgICB0eG4gTnVtQXBwQXJncwogICAgYnogbWFpbl9iYXJlX3JvdXRpbmdANgogICAgcHVzaGJ5dGVzIDB4NzIyOWQ3OWEgLy8gbWV0aG9kICJ0ZXN0X3R1cGxlX3dpdGhfcHJpbWl0aXZlX3R5cGUoKSh1aW50NjQsYm9vbCkiCiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAwCiAgICBtYXRjaCBtYWluX3Rlc3RfdHVwbGVfd2l0aF9wcmltaXRpdmVfdHlwZV9yb3V0ZUAzCgptYWluX2FmdGVyX2lmX2Vsc2VAMTA6CiAgICAvLyB0ZXN0cy9hcnRpZmFjdHMvVHVwbGVzL2NvbnRyYWN0LnB5OjgKICAgIC8vIGNsYXNzIFR1cGxlc0NvbnRyYWN0KEFSQzRDb250cmFjdCwgYXZtX3ZlcnNpb249MTEpOgogICAgcHVzaGludCAwIC8vIDAKICAgIHJldHVybgoKbWFpbl90ZXN0X3R1cGxlX3dpdGhfcHJpbWl0aXZlX3R5cGVfcm91dGVAMzoKICAgIC8vIHRlc3RzL2FydGlmYWN0cy9UdXBsZXMvY29udHJhY3QucHk6OQogICAgLy8gQGFyYzQuYWJpbWV0aG9kKCkKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgcHVzaGJ5dGVzIDB4MTUxZjdjNzUwMDAwMDAwMDAwMDAwMDAwODAKICAgIGxvZwogICAgcHVzaGludCAxIC8vIDEKICAgIHJldHVybgoKbWFpbl9iYXJlX3JvdXRpbmdANjoKICAgIC8vIHRlc3RzL2FydGlmYWN0cy9UdXBsZXMvY29udHJhY3QucHk6OAogICAgLy8gY2xhc3MgVHVwbGVzQ29udHJhY3QoQVJDNENvbnRyYWN0LCBhdm1fdmVyc2lvbj0xMSk6CiAgICB0eG4gT25Db21wbGV0aW9uCiAgICBibnogbWFpbl9hZnRlcl9pZl9lbHNlQDEwCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgIQogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBjcmVhdGluZwogICAgcHVzaGludCAxIC8vIDEKICAgIHJldHVybgo=",
+        "clear": "I3ByYWdtYSB2ZXJzaW9uIDExCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuY2xlYXJfc3RhdGVfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIHB1c2hpbnQgMSAvLyAxCiAgICByZXR1cm4K"
+    },
+    "state": {
+        "global": {
+            "num_byte_slices": 0,
+            "num_uints": 0
+        },
+        "local": {
+            "num_byte_slices": 0,
+            "num_uints": 0
+        }
+    },
+    "schema": {
+        "global": {
+            "declared": {},
+            "reserved": {}
+        },
+        "local": {
+            "declared": {},
+            "reserved": {}
+        }
+    },
+    "contract": {
+        "name": "TuplesContract",
+        "methods": [
+            {
+                "name": "test_tuple_with_primitive_type",
+                "args": [],
+                "readonly": false,
+                "returns": {
+                    "type": "(uint64,bool)"
+                }
+            }
+        ],
+        "networks": {}
+    },
+    "bare_call_config": {
+        "no_op": "CREATE"
+    }
+}

--- a/tests/artifacts/Tuples/data/TuplesContract.arc56.json
+++ b/tests/artifacts/Tuples/data/TuplesContract.arc56.json
@@ -1,0 +1,102 @@
+{
+    "name": "TuplesContract",
+    "structs": {},
+    "methods": [
+        {
+            "name": "test_tuple_with_primitive_type",
+            "args": [],
+            "returns": {
+                "type": "(uint64,bool)"
+            },
+            "actions": {
+                "create": [],
+                "call": [
+                    "NoOp"
+                ]
+            },
+            "readonly": false,
+            "events": [],
+            "recommendations": {}
+        }
+    ],
+    "arcs": [
+        22,
+        28
+    ],
+    "networks": {},
+    "state": {
+        "schema": {
+            "global": {
+                "ints": 0,
+                "bytes": 0
+            },
+            "local": {
+                "ints": 0,
+                "bytes": 0
+            }
+        },
+        "keys": {
+            "global": {},
+            "local": {},
+            "box": {}
+        },
+        "maps": {
+            "global": {},
+            "local": {},
+            "box": {}
+        }
+    },
+    "bareActions": {
+        "create": [
+            "NoOp"
+        ],
+        "call": []
+    },
+    "sourceInfo": {
+        "approval": {
+            "sourceInfo": [
+                {
+                    "pc": [
+                        25
+                    ],
+                    "errorMessage": "OnCompletion is not NoOp"
+                },
+                {
+                    "pc": [
+                        56
+                    ],
+                    "errorMessage": "can only call when creating"
+                },
+                {
+                    "pc": [
+                        28
+                    ],
+                    "errorMessage": "can only call when not creating"
+                }
+            ],
+            "pcOffsetMethod": "none"
+        },
+        "clear": {
+            "sourceInfo": [],
+            "pcOffsetMethod": "none"
+        }
+    },
+    "source": {
+        "approval": "I3ByYWdtYSB2ZXJzaW9uIDExCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuYXBwcm92YWxfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIC8vIHRlc3RzL2FydGlmYWN0cy9UdXBsZXMvY29udHJhY3QucHk6OAogICAgLy8gY2xhc3MgVHVwbGVzQ29udHJhY3QoQVJDNENvbnRyYWN0LCBhdm1fdmVyc2lvbj0xMSk6CiAgICB0eG4gTnVtQXBwQXJncwogICAgYnogbWFpbl9iYXJlX3JvdXRpbmdANgogICAgcHVzaGJ5dGVzIDB4NzIyOWQ3OWEgLy8gbWV0aG9kICJ0ZXN0X3R1cGxlX3dpdGhfcHJpbWl0aXZlX3R5cGUoKSh1aW50NjQsYm9vbCkiCiAgICB0eG5hIEFwcGxpY2F0aW9uQXJncyAwCiAgICBtYXRjaCBtYWluX3Rlc3RfdHVwbGVfd2l0aF9wcmltaXRpdmVfdHlwZV9yb3V0ZUAzCgptYWluX2FmdGVyX2lmX2Vsc2VAMTA6CiAgICAvLyB0ZXN0cy9hcnRpZmFjdHMvVHVwbGVzL2NvbnRyYWN0LnB5OjgKICAgIC8vIGNsYXNzIFR1cGxlc0NvbnRyYWN0KEFSQzRDb250cmFjdCwgYXZtX3ZlcnNpb249MTEpOgogICAgcHVzaGludCAwIC8vIDAKICAgIHJldHVybgoKbWFpbl90ZXN0X3R1cGxlX3dpdGhfcHJpbWl0aXZlX3R5cGVfcm91dGVAMzoKICAgIC8vIHRlc3RzL2FydGlmYWN0cy9UdXBsZXMvY29udHJhY3QucHk6OQogICAgLy8gQGFyYzQuYWJpbWV0aG9kKCkKICAgIHR4biBPbkNvbXBsZXRpb24KICAgICEKICAgIGFzc2VydCAvLyBPbkNvbXBsZXRpb24gaXMgbm90IE5vT3AKICAgIHR4biBBcHBsaWNhdGlvbklECiAgICBhc3NlcnQgLy8gY2FuIG9ubHkgY2FsbCB3aGVuIG5vdCBjcmVhdGluZwogICAgcHVzaGJ5dGVzIDB4MTUxZjdjNzUwMDAwMDAwMDAwMDAwMDAwODAKICAgIGxvZwogICAgcHVzaGludCAxIC8vIDEKICAgIHJldHVybgoKbWFpbl9iYXJlX3JvdXRpbmdANjoKICAgIC8vIHRlc3RzL2FydGlmYWN0cy9UdXBsZXMvY29udHJhY3QucHk6OAogICAgLy8gY2xhc3MgVHVwbGVzQ29udHJhY3QoQVJDNENvbnRyYWN0LCBhdm1fdmVyc2lvbj0xMSk6CiAgICB0eG4gT25Db21wbGV0aW9uCiAgICBibnogbWFpbl9hZnRlcl9pZl9lbHNlQDEwCiAgICB0eG4gQXBwbGljYXRpb25JRAogICAgIQogICAgYXNzZXJ0IC8vIGNhbiBvbmx5IGNhbGwgd2hlbiBjcmVhdGluZwogICAgcHVzaGludCAxIC8vIDEKICAgIHJldHVybgo=",
+        "clear": "I3ByYWdtYSB2ZXJzaW9uIDExCiNwcmFnbWEgdHlwZXRyYWNrIGZhbHNlCgovLyBhbGdvcHkuYXJjNC5BUkM0Q29udHJhY3QuY2xlYXJfc3RhdGVfcHJvZ3JhbSgpIC0+IHVpbnQ2NDoKbWFpbjoKICAgIHB1c2hpbnQgMSAvLyAxCiAgICByZXR1cm4K"
+    },
+    "byteCode": {
+        "approval": "CzEbQQAqgARyKdeaNhoAjgEAA4EAQzEZFEQxGESADRUffHUAAAAAAAAAAICwgQFDMRlA/94xGBREgQFD",
+        "clear": "C4EBQw=="
+    },
+    "compilerInfo": {
+        "compiler": "puya",
+        "compilerVersion": {
+            "major": 4,
+            "minor": 8,
+            "patch": 1
+        }
+    },
+    "events": [],
+    "templateVariables": {}
+}

--- a/tests/artifacts/Tuples/data/TuplesContract.clear.teal
+++ b/tests/artifacts/Tuples/data/TuplesContract.clear.teal
@@ -1,0 +1,7 @@
+#pragma version 11
+#pragma typetrack false
+
+// algopy.arc4.ARC4Contract.clear_state_program() -> uint64:
+main:
+    pushint 1 // 1
+    return


### PR DESCRIPTION
Adds checks to ensure that type validation applies to classes only.

Changed introduced in 0.5.0 started causing issues for abi methods that return tuple types with primitive types inside.

For instance a method like:
```py
@abimethod(allow_actions=["NoOp"])
    def test_wrapper_get_position_slot(self, user_addr: Bytes, market_slot: UInt64) -> tuple[bool, UInt64]:
        """Temporary wrapper for testing _get_position_slot."""
        return self._get_position_slot(user_addr, market_slot)
```

Would fail in serialize.py with `TypeError: issubclass() arg 1 must be a class`. The issue is due to issubclass checks that require first arg to be classes, but when elements inside are primitive types like bool it fails. PR simply tweaks the conditionals to ensure tuples are handled correctly.